### PR TITLE
Missing space for syntax

### DIFF
--- a/vignettes/CoevolutionNetworks.Rmd
+++ b/vignettes/CoevolutionNetworks.Rmd
@@ -184,7 +184,7 @@ Let's also put together a list of consensus annotations for each COG.
 consAnnots <- vector('character', length=length(CogsAnnot))
 
 # Loop along the annotations for each COG
-for ( i in seq_along(CogsAnnot) ){
+for ( i in seq_along(CogsAnnot) ) {
   taxaentry <- CogsAnnot[[i]]
   
   # If no annotation, it's a noncoding gene


### PR DESCRIPTION
Otherwise the block errors out with
```
Error: Incomplete expression:   taxaentry <- CogsAnnot[[i]]
  
  # If no annotation, it's a noncoding gene
  if (!is(taxaentry, 'Taxa'))
    consAnnots[[i]] <- 'NONCODING'
  # Otherwise it's a coding gene
  else {
    # Grab all the annotations aside from "Unclassified"
    annots <- sapply(taxaentry, \(y) y$taxon[length(y$taxon)])
    annots <- annots[annots!='unclassified_Root']
    
    # If we only have "Unclassified", just mark it as uncharacterized
    if (length(annots) == 0)
      consAnnots[[i]] <- 'Uncharacterized'
    
    # Otherwise take the most common annotation
    else
      consAnnots[[i]] <- names(sort(table(annots), decreasing=T))[1]
  }
}
> }
Error: unexpected '}' in "}"
```
when running the vignette.

This was found during a quick pass of the vignettes in preparation for Smorgasbord 2023.